### PR TITLE
Add JWT presence verification with fallback & fix mascot rendering for Android

### DIFF
--- a/app/lib/map/mascot_annotations.dart
+++ b/app/lib/map/mascot_annotations.dart
@@ -1,7 +1,6 @@
 import 'dart:convert' as convert;
 import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart' as mb;
@@ -126,10 +125,6 @@ class MascotAnnotations {
 
   String _modelUri(String flutterAssetPath) {
     if (flutterAssetPath.startsWith("asset://")) return flutterAssetPath;
-
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      return "asset://flutter_assets/$flutterAssetPath";
-    }
     return "asset://$flutterAssetPath";
   }
 

--- a/app/lib/map/player_model_controller.dart
+++ b/app/lib/map/player_model_controller.dart
@@ -53,9 +53,6 @@ class PlayerModelController {
 
   String _modelUri(String flutterAssetPath) {
     if (flutterAssetPath.startsWith("asset://")) return flutterAssetPath;
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      return "asset://flutter_assets/$flutterAssetPath";
-    }
     return "asset://$flutterAssetPath";
   }
 

--- a/app/lib/screens/4_mascot_screen.dart
+++ b/app/lib/screens/4_mascot_screen.dart
@@ -139,7 +139,7 @@ class _MascotScreenState extends State<MascotScreen>
           device = await _scanForBeacon(_serviceUuid);
           if (!mounted) return;
 
-          setState(() { _verificationStatus = 'Verifying presence…'; });
+          setState(() { _verificationStatus = 'Still Going…'; });
 
           await device.connect(timeout: const Duration(seconds: 10), autoConnect: false);
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   csslib:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.3
+  cryptography: ^2.7.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Adds JWT-based mascot presence verification in 4_mascot_screen.dart, including challenge signing, bridge/Pi resolution, cached JWT storage, and fallback to the legacy Fastify verification flow when needed.

Closes #83 #84 

Also changed:
- 3.1_mapbox_screen.dart: to reduce Android map load by lowering tilt and throttling heading/camera updates during auto-follow
- mascot_annotations.dart and player_model_controller.dart to simplify model asset URI handling
- pubspec.yaml to add cryptography for Ed25519 challenge signing


Demos here show the latest version: https://drive.google.com/drive/u/4/folders/12j_JQyCRFvpcNaqQsga6_-p5gBVm5Vcj