### PR TITLE
Refactor verification flow and extract helper

### DIFF
--- a/app/lib/map/map_ids.dart
+++ b/app/lib/map/map_ids.dart
@@ -28,7 +28,7 @@ class MapIds {
   static const double maxCameraUpdateHz = 10;
 
   static const double playerModelHeadingOffset = 180.0;
-  static const double mascotModelScale = 25.0;
+  static const double mascotModelScale = 35.0;
   
   // Increased height from 0.0 to 3.0 meters to prevent mascots from being buried in the ground/terrain
   static const double mascotModelHeightMeters = 3.0;

--- a/app/lib/map/mascot_annotations.dart
+++ b/app/lib/map/mascot_annotations.dart
@@ -1,7 +1,6 @@
 import 'dart:convert' as convert;
 import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart' as mb;
@@ -126,10 +125,6 @@ class MascotAnnotations {
 
   String _modelUri(String flutterAssetPath) {
     if (flutterAssetPath.startsWith("asset://")) return flutterAssetPath;
-
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      return "asset://flutter_assets/$flutterAssetPath";
-    }
     return "asset://$flutterAssetPath";
   }
 

--- a/app/lib/map/player_model_controller.dart
+++ b/app/lib/map/player_model_controller.dart
@@ -53,9 +53,6 @@ class PlayerModelController {
 
   String _modelUri(String flutterAssetPath) {
     if (flutterAssetPath.startsWith("asset://")) return flutterAssetPath;
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      return "asset://flutter_assets/$flutterAssetPath";
-    }
     return "asset://$flutterAssetPath";
   }
 

--- a/app/lib/screens/10_profile_screen.dart
+++ b/app/lib/screens/10_profile_screen.dart
@@ -2,8 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:app/state/current_user.dart';
 import 'package:app/utils/routes.dart';
 
-class ProfileScreen extends StatelessWidget {
+class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
+
+  @override
+  State<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends State<ProfileScreen> {
+  Future<void> _openInventory() async {
+    await Navigator.pushNamed(context, Routes.inventory);
+    if (!mounted) return;
+    setState(() {});
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -96,9 +107,7 @@ class ProfileScreen extends StatelessWidget {
                   SizedBox(
                     width: double.infinity,
                     child: ElevatedButton(
-                      onPressed: () {
-                        Navigator.pushNamed(context, Routes.inventory);
-                      },
+                      onPressed: _openInventory,
                       style: _buttonStyle(),
                       child: Text(
                         "My Collection (${user.caughtMascots.length})",

--- a/app/lib/screens/4_mascot_screen.dart
+++ b/app/lib/screens/4_mascot_screen.dart
@@ -139,7 +139,7 @@ class _MascotScreenState extends State<MascotScreen>
           device = await _scanForBeacon(_serviceUuid);
           if (!mounted) return;
 
-          setState(() { _verificationStatus = 'Verifying presence…'; });
+          setState(() { _verificationStatus = 'Still Going…'; });
 
           await device.connect(timeout: const Duration(seconds: 10), autoConnect: false);
 

--- a/app/lib/screens/4_mascot_screen.dart
+++ b/app/lib/screens/4_mascot_screen.dart
@@ -1,19 +1,13 @@
-// 4_mascot_screen.dart
 import 'dart:async';
-import 'dart:convert';
-import 'dart:typed_data';
 
-import 'package:cryptography/cryptography.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_blue_plus/flutter_blue_plus.dart';
-import 'package:http/http.dart' as http;
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:app/state/current_user.dart';
 import 'package:app/apis/user_api.dart';
 import 'package:app/apis/mascot_api.dart';
 import 'package:app/models/mascot.dart';
 import 'package:app/screens/helpers.dart';
+import 'package:app/utils/mascot_verification_helper.dart';
 
 import '6_catch_screen.dart';
 
@@ -29,9 +23,13 @@ class MascotScreen extends StatefulWidget {
 
 class _MascotScreenState extends State<MascotScreen>
     with SingleTickerProviderStateMixin {
+  static const String _verificationFailedMessage = 
+      'We couldn’t verify your presence. Ensure you are at the correct location and try again.';
+  static const String _verifyingStatusMessage = 'Verifying presence…';
+  static const String _legacyFallbackStatusMessage =
+      'Hold tight — this is taking a little longer than usual…';
   bool _isVerifying = false;
   String _verificationStatus = 'Tap "Challenge" to start!';
-  String? _lastJwtFailure;
   bool _hasCaughtMascot = false;
   bool _hasAttempted = false;
 
@@ -43,37 +41,18 @@ class _MascotScreenState extends State<MascotScreen>
   late final String _mascotLocation = 'UCSB Campus Area';
 
   late final AnimationController _pulseController;
+  late final MascotVerificationHelper _verificationHelper;
 
-  // JWT backend (follows mentor given sequence) + legacy Render fallback which used typescript
   static const bool _useJwtPrimary = true;
   static const bool _allowLegacyFallback = true;
-  static const String _jwtApiBase = "https://jwt-verification-sk0m.onrender.com";
-  static const String _legacyApiBase = "https://spacescrypt-api.onrender.com";
-  static const String _jwtUserId = "user1";
-  // Orbitport cTRNG can add latency; allow realistic discovery budget.
-  static const Duration _bridgeDiscoveryTimeout = Duration(seconds: 8);
-  static const Duration _bridgeProbeTimeout = Duration(milliseconds: 3000);
-  // Allow realistic mobile->Render round trip.
-  static const Duration _jwtBackendTimeout = Duration(seconds: 6);
-  static const List<String> _defaultBridgeCandidates = [
-    "http://127.0.0.1:8080",
-    "http://10.0.2.2:8080",
-    "http://localhost:8080",
-    "http://raspberrypi.local:8080",
-    "http://pi.local:8080",
-  ];
-  // Ed25519 seed used by app to sign challenge as user1.
-  static const String _jwtUserSeedHex = "3ef871ad732fc316c2dcd8baef06a49d4097de4e98ea746d9a31c605412b8105";
-
-  static final Guid _serviceUuid = Guid("eb5c86a4-733c-4d9d-aab2-285c2dab09a1");
-  static final Guid _idCharUuid = Guid("eb5c86a4-733c-4d9d-aab2-285c2dab09a2");
-  static final Guid _signNonceUuid = Guid("eb5c86a4-733c-4d9d-aab2-285c2dab09a3");
-  static final Guid _signRespUuid = Guid("eb5c86a4-733c-4d9d-aab2-285c2dab09a4");
+  static const Duration _jwtAttemptDuration = Duration(seconds: 3);
+  static const Duration _legacyAttemptDuration = Duration(seconds: 3);
 
   @override
   void initState() {
     super.initState();
     _loadMascot();
+    _verificationHelper = MascotVerificationHelper(widgetPiId: widget.piId);
 
     _pulseController = AnimationController(
       vsync: this,
@@ -100,90 +79,15 @@ class _MascotScreenState extends State<MascotScreen>
     setState(() {
       _isVerifying = true;
       _hasAttempted = true;
-      _verificationStatus = 'Getting nonce…';
+      _verificationStatus = _verifyingStatusMessage;
       _coins -= coinsToChallenge;
     });
 
     CurrentUser.user!.coins -= coinsToChallenge;
     updateUser(CurrentUser.user!, context);
 
-    BluetoothDevice? device;
-    StreamSubscription<List<int>>? notifSub;
-
     try {
-      bool ok = false;
-
-      // Skip verification check if username is "1"
-      if (username == "1") {
-        ok = true;
-      } else {
-        if (_useJwtPrimary) {
-          if (!mounted) return;
-          setState(() { _verificationStatus = 'Verifying presence…'; });
-          ok = await _runJwtPrimaryFlow();
-        }
-
-        if (!ok && _allowLegacyFallback) {
-          if (!mounted) return;
-          // setState(() {
-          //   final reason = _lastJwtFailure;
-          //   _verificationStatus = (reason == null || reason.isEmpty)
-          //       ? 'JWT failed, trying fallback…'
-          //       : 'JWT failed ($reason), trying fallback…';
-          // });
-          final nonceHex = await _fetchNonceHex();
-          if (!mounted) return;
-
-          setState(() { _verificationStatus = 'Connecting…'; });
-
-          device = await _scanForBeacon(_serviceUuid);
-          if (!mounted) return;
-
-          setState(() { _verificationStatus = 'Still Going…'; });
-
-          await device.connect(timeout: const Duration(seconds: 10), autoConnect: false);
-
-          final services = await device.discoverServices();
-          final svc = services.firstWhere((s) => s.uuid == _serviceUuid);
-
-          final idChar = svc.characteristics.firstWhere((c) => c.uuid == _idCharUuid);
-          final signNonceChar = svc.characteristics.firstWhere((c) => c.uuid == _signNonceUuid);
-          final signRespChar = svc.characteristics.firstWhere((c) => c.uuid == _signRespUuid);
-
-          final idBytes = await idChar.read();
-          final beaconIdHex = _bytesToHex(idBytes).toLowerCase();
-
-          await signRespChar.setNotifyValue(true);
-
-          final completer = Completer<Uint8List>();
-          notifSub = signRespChar.onValueReceived.listen((value) {
-            final raw = Uint8List.fromList(value);
-            if (raw.length == 72 && !completer.isCompleted) {
-              completer.complete(raw);
-            }
-          });
-
-          final nonceBytes = _hexToBytes(nonceHex);
-          await signNonceChar.write(nonceBytes, withoutResponse: true);
-
-          final raw = await completer.future.timeout(
-            const Duration(seconds: 6),
-            onTimeout: () => throw Exception("Verification timed out"),
-          );
-
-          final tsBytes = raw.sublist(0, 8);
-          final sigBytes = raw.sublist(8);
-          final tsMs = _be64ToMs(tsBytes);
-          final sigHex = _bytesToHex(sigBytes).toLowerCase();
-
-          ok = await _postVerifyLegacy(
-            beaconIdHex: beaconIdHex,
-            nonceHex: nonceHex,
-            tsMs: tsMs.toString(),
-            sigHex: sigHex,
-          );
-        }
-      }
+      final ok = await _runVerificationFlow();
 
       if (!mounted) return;
 
@@ -199,6 +103,7 @@ class _MascotScreenState extends State<MascotScreen>
           CurrentUser.user!.visitedPis.add(widget.piId);
           CurrentUser.user!.lastPiVisited = widget.piId;
           await updateUser(CurrentUser.user!, context);
+          if (!mounted) return;
         }
 
         if (CurrentUser.user!.lastPiVisited != widget.piId) {
@@ -209,6 +114,7 @@ class _MascotScreenState extends State<MascotScreen>
           );
           CurrentUser.user!.lastPiVisited = widget.piId;
           await updateUser(CurrentUser.user!, context);
+          if (!mounted) return;
         }
 
         final didCatch = await Navigator.push<bool>(
@@ -228,280 +134,104 @@ class _MascotScreenState extends State<MascotScreen>
       } else {
         setState(() {
           _isVerifying = false;
-          _verificationStatus = 'Verification failed';
+          _verificationStatus = _verificationFailedMessage;
         });
       }
     } catch (e) {
       if (!mounted) return;
       setState(() {
         _isVerifying = false;
-        _verificationStatus = 'Verification error: $e';
+        _verificationStatus = _verificationFailedMessage;
       });
-    } finally {
-      try { await notifSub?.cancel(); } catch (_) {}
-      try { if (device != null) await device.disconnect(); } catch (_) {}
     }
+  }
+
+  Future<bool> _runVerificationFlow() async {
+    if (username == "1") {
+      return true;
+    }
+
+    if (!_useJwtPrimary) {
+      if (!_allowLegacyFallback || !mounted) return false;
+      setState(() {
+        _verificationStatus = _legacyFallbackStatusMessage;
+      });
+      return _runLegacyFallbackFlow(_legacyAttemptDuration);
+    }
+
+    var jwtCompleted = false;
+    var jwtResult = false;
+    final jwtSuccess = Completer<bool>();
+    final jwtFuture = _runJwtPrimaryFlow().then((ok) {
+      jwtCompleted = true;
+      jwtResult = ok;
+      if (ok && !jwtSuccess.isCompleted) {
+        jwtSuccess.complete(true);
+      }
+      return ok;
+    });
+
+    await Future.any<dynamic>([
+      jwtSuccess.future,
+      Future.delayed(_jwtAttemptDuration),
+    ]);
+
+    if (jwtCompleted && jwtResult) {
+      return true;
+    }
+
+    if (!_allowLegacyFallback || !mounted) {
+      final remainingJwtBudget =
+          jwtCompleted ? Duration.zero : _legacyAttemptDuration;
+      if (remainingJwtBudget == Duration.zero) {
+        return false;
+      }
+      return jwtFuture.timeout(
+        remainingJwtBudget,
+        onTimeout: () => false,
+      );
+    }
+
+    setState(() {
+      _verificationStatus = _legacyFallbackStatusMessage;
+    });
+
+    final legacyFuture = _runLegacyFallbackFlow(_legacyAttemptDuration);
+
+    if (jwtCompleted) {
+      return legacyFuture.timeout(
+        _legacyAttemptDuration,
+        onTimeout: () => false,
+      );
+    }
+
+    final overlapResult = Completer<bool>();
+    var remainingFlows = 2;
+
+    void settleOverlap(bool ok) {
+      remainingFlows -= 1;
+      if (ok && !overlapResult.isCompleted) {
+        overlapResult.complete(true);
+      } else if (remainingFlows == 0 && !overlapResult.isCompleted) {
+        overlapResult.complete(false);
+      }
+    }
+
+    jwtFuture.then(settleOverlap);
+    legacyFuture.then(settleOverlap);
+
+    return Future.any<bool>([
+      overlapResult.future,
+      Future.delayed(_legacyAttemptDuration, () => false),
+    ]);
   }
 
   Future<bool> _runJwtPrimaryFlow() async {
-    try {
-      final preferredPiId = await _getStoredPiJwtId();
-      final resolved = await _resolveBridgeFromBackend(preferredPiId);
-      final resolvedPiId = (resolved?["pi_id"] as String?) ?? preferredPiId;
-      final packet = await _fetchPiSignedChallenge(
-        resolvedPiId,
-        resolvedBridge: resolved?["bridge_url"] as String?,
-      ).timeout(
-        _bridgeDiscoveryTimeout,
-        onTimeout: () => throw Exception("Pi discovery timed out (>8s)"),
-      );
-      final piId = packet["pi_id"] as String? ?? resolvedPiId;
-      final challenge = packet["challenge"] as String? ?? "";
-      final piSignature = packet["pi_signature"] as String? ?? "";
-
-      if (challenge.isEmpty || piSignature.isEmpty) {
-        throw Exception("Pi returned empty challenge/signature");
-      }
-
-      await _storePiJwtId(piId);
-
-      final userSignature = await _signChallengeWithAppKey(challenge);
-      return _postJwtExchange(
-        piId: piId,
-        challenge: challenge,
-        piSignature: piSignature,
-        userSignature: userSignature,
-      );
-    } catch (e) {
-      _lastJwtFailure = e.toString();
-      // for debug
-      // if (mounted) {
-      //   setState(() {
-      //     _verificationStatus = "JWT primary failed: $e";
-      //   });
-      // }
-      return false;
-    }
+    return _verificationHelper.runJwtPrimaryFlow();
   }
 
-  Future<Map<String, dynamic>> _fetchPiSignedChallenge(
-    String preferredPiId, {
-    String? resolvedBridge,
-  }) async {
-    final candidates = await _bridgeCandidates(
-      preferredPiId,
-      resolvedBridge: resolvedBridge,
-    );
-
-    for (final base in candidates) {
-      try {
-        final uriWithPi = Uri.parse(
-          "$base/challenge"
-          "?user_id=$_jwtUserId&pi_id=${Uri.encodeQueryComponent(preferredPiId)}"
-        );
-        http.Response r = await http.get(uriWithPi).timeout(_bridgeProbeTimeout);
-
-        if (r.statusCode != 200) {
-          // Retry without pi_id for bridges that do not accept unknown ids.
-          final uriNoPi = Uri.parse("$base/challenge?user_id=$_jwtUserId");
-          r = await http.get(uriNoPi).timeout(_bridgeProbeTimeout);
-        }
-
-        if (r.statusCode != 200) {
-          continue;
-        }
-        final payload = jsonDecode(r.body) as Map<String, dynamic>;
-        final challenge = payload["challenge"] as String? ?? "";
-        final piSig = payload["pi_signature"] as String? ?? "";
-        if (challenge.isEmpty || piSig.isEmpty) {
-          continue;
-        }
-        await _storeBridgeBase(base);
-        return payload;
-      } catch (_) {
-        continue;
-      }
-    }
-    throw Exception("No Pi bridge reachable");
-  }
-
-  Future<Map<String, dynamic>?> _resolveBridgeFromBackend(String piId) async {
-    try {
-      final withPi = Uri.parse(
-        "$_jwtApiBase/presence/pi/resolve?pi_id=${Uri.encodeQueryComponent(piId)}"
-      );
-      final r1 = await http.get(withPi).timeout(_bridgeProbeTimeout);
-      if (r1.statusCode == 200) {
-        final payload = jsonDecode(r1.body) as Map<String, dynamic>;
-        final bridge = payload["bridge_url"] as String?;
-        if (bridge != null && bridge.isNotEmpty) return payload;
-      }
-
-      final withoutPi = Uri.parse("$_jwtApiBase/presence/pi/resolve");
-      final r2 = await http.get(withoutPi).timeout(_bridgeProbeTimeout);
-      if (r2.statusCode != 200) return null;
-      final payload2 = jsonDecode(r2.body) as Map<String, dynamic>;
-      final bridge2 = payload2["bridge_url"] as String?;
-      if (bridge2 == null || bridge2.isEmpty) return null;
-      return payload2;
-    } catch (_) {
-      return null;
-    }
-  }
-
-  Future<String> _signChallengeWithAppKey(String challenge) async {
-    final algorithm = Ed25519();
-    final seed = _hexToBytes(_jwtUserSeedHex);
-    final keyPair = await algorithm.newKeyPairFromSeed(seed);
-    final sig = await algorithm.sign(utf8.encode(challenge), keyPair: keyPair);
-    return _bytesToHex(sig.bytes).toLowerCase();
-  }
-
-  Future<bool> _postJwtExchange({
-    required String piId,
-    required String challenge,
-    required String piSignature,
-    required String userSignature,
-  }) async {
-    try {
-      final r = await http.post(
-        Uri.parse("$_jwtApiBase/presence/exchange"),
-        headers: {"Content-Type": "application/json"},
-        body: jsonEncode({
-          "user_id": _jwtUserId,
-          "pi_id": piId,
-          "challenge": challenge,
-          "pi_signature": piSignature,
-          "user_signature": userSignature,
-        }),
-      ).timeout(_jwtBackendTimeout);
-
-      if (r.statusCode != 200) {
-        if (r.statusCode == 401 && r.body.contains("Invalid Pi signature")) {
-          await _clearPiBridgeCache();
-        }
-        throw Exception("JWT exchange failed (${r.statusCode}): ${r.body}");
-      }
-      final json = jsonDecode(r.body) as Map<String, dynamic>;
-      final jwt = (json["presence_jwt"] as String?) ?? "";
-      final sid = (json["sid"] as String?) ?? "";
-      if (jwt.isEmpty) {
-        throw Exception("JWT missing in response");
-      }
-      await _storePresenceJwt(jwt, sid);
-      _lastJwtFailure = null;
-      return true;
-    } catch (e) {
-      _lastJwtFailure = e.toString();
-      if (mounted) {
-        setState(() {
-          _verificationStatus = "JWT exchange error: $e";
-        });
-      }
-      return false;
-    }
-  }
-
-  Future<void> _storePresenceJwt(String jwt, String sid) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString("presence_jwt", jwt);
-    await prefs.setString("presence_sid", sid);
-  }
-
-  String _piJwtPrefKey() => "jwt_pi_id_for_widget_pi_${widget.piId}";
-  String _piBridgePrefKey() => "jwt_pi_bridge_for_widget_pi_${widget.piId}";
-
-  String _defaultPiJwtId() => "pi${widget.piId}";
-
-  Future<String> _getStoredPiJwtId() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_piJwtPrefKey()) ?? _defaultPiJwtId();
-  }
-
-  Future<void> _storePiJwtId(String piId) async {
-    if (piId.isEmpty) return;
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_piJwtPrefKey(), piId);
-  }
-
-  Future<List<String>> _bridgeCandidates(
-    String preferredPiId, {
-    String? resolvedBridge,
-  }) async {
-    final prefs = await SharedPreferences.getInstance();
-    final stored = prefs.getString(_piBridgePrefKey());
-    final merged = <String>[
-      if (resolvedBridge != null && resolvedBridge.isNotEmpty) resolvedBridge,
-      if (stored != null && stored.isNotEmpty) stored,
-      "http://$preferredPiId.local:8080",
-      ..._defaultBridgeCandidates,
-    ];
-    final seen = <String>{};
-    final out = <String>[];
-    for (final b in merged) {
-      if (seen.add(b)) out.add(b);
-    }
-    return out;
-  }
-
-  Future<void> _storeBridgeBase(String base) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_piBridgePrefKey(), base);
-  }
-
-  Future<void> _clearPiBridgeCache() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_piBridgePrefKey());
-    await prefs.remove(_piJwtPrefKey());
-  }
-
-  Future<String> _fetchNonceHex() async {
-    final r = await http.get(Uri.parse("$_legacyApiBase/api/nonce"));
-    if (r.statusCode != 200) throw Exception("nonce failed");
-    final json = jsonDecode(r.body);
-    return (json["nonceHex"] as String).toLowerCase();
-  }
-
-  Future<bool> _postVerifyLegacy({required String beaconIdHex, required String nonceHex, required String tsMs, required String sigHex}) async {
-    final r = await http.post(
-      Uri.parse("$_legacyApiBase/api/verify"),
-      headers: {"Content-Type": "application/json"},
-      body: jsonEncode({"beaconIdHex": beaconIdHex, "nonceHex": nonceHex, "tsMs": tsMs, "sigHex": sigHex}),
-    );
-    return jsonDecode(r.body)["ok"] == true;
-  }
-
-  Future<BluetoothDevice> _scanForBeacon(Guid serviceUuid) async {
-    try { await FlutterBluePlus.stopScan(); } catch (_) {}
-    BluetoothDevice? found;
-    final sub = FlutterBluePlus.scanResults.listen((results) {
-      for (final r in results) {
-        if (r.advertisementData.serviceUuids.contains(serviceUuid)) {
-          found = r.device;
-          break;
-        }
-      }
-    });
-    await FlutterBluePlus.startScan(withServices: [serviceUuid], timeout: const Duration(seconds: 12));
-    await Future.delayed(const Duration(seconds: 12));
-    await FlutterBluePlus.stopScan();
-    await sub.cancel();
-    if (found == null) throw Exception("No beacon found");
-    return found!;
-  }
-
-  static String _bytesToHex(List<int> b) => b.map((x) => x.toRadixString(16).padLeft(2, "0")).join();
-  static Uint8List _hexToBytes(String hex) {
-    final out = Uint8List(hex.length ~/ 2);
-    for (int i = 0; i < out.length; i++) {
-      out[i] = int.parse(hex.substring(i * 2, i * 2 + 2), radix: 16);
-    }
-    return out;
-  }
-  static int _be64ToMs(Uint8List u8) {
-    BigInt n = BigInt.zero;
-    for (int i = 0; i < 8; i++) n = (n << 8) | BigInt.from(u8[i]);
-    return n.toInt();
+  Future<bool> _runLegacyFallbackFlow(Duration budget) async {
+    return _verificationHelper.runLegacyFallbackFlow(budget);
   }
 
   void claimCoin(int numCoins, {String? message}) {
@@ -513,7 +243,9 @@ class _MascotScreenState extends State<MascotScreen>
 
   Color _statusColor() {
     if (_isVerifying) return Colors.amber.shade300;
-    if (_verificationStatus.contains('failed') || _verificationStatus.contains('error')) return Colors.redAccent.shade200;
+    if (_verificationStatus == _verificationFailedMessage) {
+      return Colors.redAccent.shade200;
+    }
     if (_hasCaughtMascot) return Colors.lightGreenAccent.shade400;
     return Colors.white70;
   }

--- a/app/lib/screens/6_catch_screen.dart
+++ b/app/lib/screens/6_catch_screen.dart
@@ -188,6 +188,10 @@ class _CatchScreenState extends State<CatchScreen>
     final u = CurrentUser.user;
     if (u == null) return;
 
+    if (!u.caughtMascots.contains(widget.mascot.mascotId)) {
+      u.caughtMascots.add(widget.mascot.mascotId);
+    }
+
     await _firestore.collection('users').doc(u.username).update({
       'caughtMascots': FieldValue.arrayUnion([widget.mascot.mascotId]),
       // 'coins': FieldValue.increment(1),

--- a/app/lib/screens/8_inventory_screen.dart
+++ b/app/lib/screens/8_inventory_screen.dart
@@ -47,6 +47,10 @@ class _InventoryScreenState extends State<InventoryScreen> {
       final List<int> userMascotIds =
           await getCaughtMascotsOfUser(CurrentUser.user!.username);
 
+      if (CurrentUser.user != null) {
+        CurrentUser.user!.caughtMascots = List<int>.from(userMascotIds);
+      }
+
       final List<Mascot> fetchedMascots =
           await getMascotsByIds(userMascotIds);
 

--- a/app/lib/utils/mascot_verification_helper.dart
+++ b/app/lib/utils/mascot_verification_helper.dart
@@ -1,0 +1,410 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MascotVerificationHelper {
+  MascotVerificationHelper({required this.widgetPiId});
+
+  final int widgetPiId;
+
+  static const String _jwtApiBase = "https://jwt-verification-sk0m.onrender.com";
+  static const String _legacyApiBase = "https://spacescrypt-api.onrender.com";
+  static const String _jwtUserId = "user1";
+  static const Duration _bridgeProbeTimeout = Duration(milliseconds: 3000);
+  static const Duration _jwtBackendTimeout = Duration(seconds: 3);
+  static const List<String> _defaultBridgeCandidates = [
+    "http://127.0.0.1:8080",
+    "http://10.0.2.2:8080",
+    "http://localhost:8080",
+    "http://raspberrypi.local:8080",
+    "http://pi.local:8080",
+  ];
+  static const String _jwtUserSeedHex =
+      "3ef871ad732fc316c2dcd8baef06a49d4097de4e98ea746d9a31c605412b8105";
+
+  static final Guid _serviceUuid =
+      Guid("eb5c86a4-733c-4d9d-aab2-285c2dab09a1");
+  static final Guid _idCharUuid =
+      Guid("eb5c86a4-733c-4d9d-aab2-285c2dab09a2");
+  static final Guid _signNonceUuid =
+      Guid("eb5c86a4-733c-4d9d-aab2-285c2dab09a3");
+  static final Guid _signRespUuid =
+      Guid("eb5c86a4-733c-4d9d-aab2-285c2dab09a4");
+
+  Future<bool> runJwtPrimaryFlow() async {
+    try {
+      final preferredPiId = await _getStoredPiJwtId();
+      final resolved = await _resolveBridgeFromBackend(preferredPiId);
+      final resolvedPiId = (resolved?["pi_id"] as String?) ?? preferredPiId;
+      final packet = await _fetchPiSignedChallenge(
+        resolvedPiId,
+        resolvedBridge: resolved?["bridge_url"] as String?,
+      );
+      final piId = packet["pi_id"] as String? ?? resolvedPiId;
+      final challenge = packet["challenge"] as String? ?? "";
+      final piSignature = packet["pi_signature"] as String? ?? "";
+
+      if (challenge.isEmpty || piSignature.isEmpty) {
+        throw Exception("Pi returned empty challenge/signature");
+      }
+
+      await _storePiJwtId(piId);
+
+      final userSignature = await _signChallengeWithAppKey(challenge);
+      return _postJwtExchange(
+        piId: piId,
+        challenge: challenge,
+        piSignature: piSignature,
+        userSignature: userSignature,
+      );
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<bool> runLegacyFallbackFlow(Duration budget) async {
+    BluetoothDevice? device;
+    StreamSubscription<List<int>>? notifSub;
+    final deadline = DateTime.now().add(budget);
+
+    Duration remaining() {
+      final left = deadline.difference(DateTime.now());
+      return left.isNegative ? Duration.zero : left;
+    }
+
+    try {
+      final nonceHex = await _fetchNonceHex().timeout(
+        remaining(),
+        onTimeout: () => throw Exception("Legacy nonce timed out"),
+      );
+      final scanBudget = remaining();
+      if (scanBudget == Duration.zero) return false;
+
+      device = await _scanForBeacon(timeout: scanBudget);
+
+      final connectBudget = remaining();
+      if (connectBudget == Duration.zero) return false;
+      await device.connect(timeout: connectBudget, autoConnect: false);
+
+      final services = await device.discoverServices().timeout(
+        remaining(),
+        onTimeout: () => throw Exception("Service discovery timed out"),
+      );
+      final svc = services.firstWhere((s) => s.uuid == _serviceUuid);
+
+      final idChar = svc.characteristics.firstWhere((c) => c.uuid == _idCharUuid);
+      final signNonceChar = svc.characteristics.firstWhere(
+        (c) => c.uuid == _signNonceUuid,
+      );
+      final signRespChar = svc.characteristics.firstWhere(
+        (c) => c.uuid == _signRespUuid,
+      );
+
+      final idBytes = await idChar.read().timeout(
+        remaining(),
+        onTimeout: () => throw Exception("Beacon read timed out"),
+      );
+      final beaconIdHex = _bytesToHex(idBytes).toLowerCase();
+
+      await signRespChar.setNotifyValue(true).timeout(
+        remaining(),
+        onTimeout: () => throw Exception("Notification setup timed out"),
+      );
+
+      final completer = Completer<Uint8List>();
+      notifSub = signRespChar.onValueReceived.listen((value) {
+        final raw = Uint8List.fromList(value);
+        if (raw.length == 72 && !completer.isCompleted) {
+          completer.complete(raw);
+        }
+      });
+
+      final nonceBytes = _hexToBytes(nonceHex);
+      await signNonceChar.write(nonceBytes, withoutResponse: true).timeout(
+        remaining(),
+        onTimeout: () => throw Exception("Nonce write timed out"),
+      );
+
+      final responseBudget = remaining();
+      if (responseBudget == Duration.zero) return false;
+      final raw = await completer.future.timeout(
+        responseBudget,
+        onTimeout: () => throw Exception("Legacy verification timed out"),
+      );
+
+      final tsBytes = raw.sublist(0, 8);
+      final sigBytes = raw.sublist(8);
+      final tsMs = _be64ToMs(tsBytes);
+      final sigHex = _bytesToHex(sigBytes).toLowerCase();
+
+      return _postVerifyLegacy(
+        beaconIdHex: beaconIdHex,
+        nonceHex: nonceHex,
+        tsMs: tsMs.toString(),
+        sigHex: sigHex,
+      ).timeout(
+        remaining(),
+        onTimeout: () => false,
+      );
+    } catch (_) {
+      return false;
+    } finally {
+      try {
+        await notifSub?.cancel();
+      } catch (_) {}
+      try {
+        if (device != null) await device.disconnect();
+      } catch (_) {}
+    }
+  }
+
+  Future<Map<String, dynamic>> _fetchPiSignedChallenge(
+    String preferredPiId, {
+    String? resolvedBridge,
+  }) async {
+    final candidates = await _bridgeCandidates(
+      preferredPiId,
+      resolvedBridge: resolvedBridge,
+    );
+
+    for (final base in candidates) {
+      try {
+        final uriWithPi = Uri.parse(
+          "$base/challenge"
+          "?user_id=$_jwtUserId&pi_id=${Uri.encodeQueryComponent(preferredPiId)}",
+        );
+        http.Response response =
+            await http.get(uriWithPi).timeout(_bridgeProbeTimeout);
+
+        if (response.statusCode != 200) {
+          final uriNoPi = Uri.parse("$base/challenge?user_id=$_jwtUserId");
+          response = await http.get(uriNoPi).timeout(_bridgeProbeTimeout);
+        }
+
+        if (response.statusCode != 200) {
+          continue;
+        }
+
+        final payload = jsonDecode(response.body) as Map<String, dynamic>;
+        final challenge = payload["challenge"] as String? ?? "";
+        final piSig = payload["pi_signature"] as String? ?? "";
+        if (challenge.isEmpty || piSig.isEmpty) {
+          continue;
+        }
+        await _storeBridgeBase(base);
+        return payload;
+      } catch (_) {
+        continue;
+      }
+    }
+
+    throw Exception("No Pi bridge reachable");
+  }
+
+  Future<Map<String, dynamic>?> _resolveBridgeFromBackend(String piId) async {
+    try {
+      final withPi = Uri.parse(
+        "$_jwtApiBase/presence/pi/resolve?pi_id=${Uri.encodeQueryComponent(piId)}",
+      );
+      final r1 = await http.get(withPi).timeout(_bridgeProbeTimeout);
+      if (r1.statusCode == 200) {
+        final payload = jsonDecode(r1.body) as Map<String, dynamic>;
+        final bridge = payload["bridge_url"] as String?;
+        if (bridge != null && bridge.isNotEmpty) return payload;
+      }
+
+      final withoutPi = Uri.parse("$_jwtApiBase/presence/pi/resolve");
+      final r2 = await http.get(withoutPi).timeout(_bridgeProbeTimeout);
+      if (r2.statusCode != 200) return null;
+
+      final payload = jsonDecode(r2.body) as Map<String, dynamic>;
+      final bridge = payload["bridge_url"] as String?;
+      if (bridge == null || bridge.isEmpty) return null;
+      return payload;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<String> _signChallengeWithAppKey(String challenge) async {
+    final algorithm = Ed25519();
+    final seed = _hexToBytes(_jwtUserSeedHex);
+    final keyPair = await algorithm.newKeyPairFromSeed(seed);
+    final sig = await algorithm.sign(utf8.encode(challenge), keyPair: keyPair);
+    return _bytesToHex(sig.bytes).toLowerCase();
+  }
+
+  Future<bool> _postJwtExchange({
+    required String piId,
+    required String challenge,
+    required String piSignature,
+    required String userSignature,
+  }) async {
+    try {
+      final response = await http
+          .post(
+            Uri.parse("$_jwtApiBase/presence/exchange"),
+            headers: {"Content-Type": "application/json"},
+            body: jsonEncode({
+              "user_id": _jwtUserId,
+              "pi_id": piId,
+              "challenge": challenge,
+              "pi_signature": piSignature,
+              "user_signature": userSignature,
+            }),
+          )
+          .timeout(_jwtBackendTimeout);
+
+      if (response.statusCode != 200) {
+        if (response.statusCode == 401 &&
+            response.body.contains("Invalid Pi signature")) {
+          await _clearPiBridgeCache();
+        }
+        throw Exception("JWT exchange failed (${response.statusCode})");
+      }
+
+      final payload = jsonDecode(response.body) as Map<String, dynamic>;
+      final jwt = (payload["presence_jwt"] as String?) ?? "";
+      final sid = (payload["sid"] as String?) ?? "";
+      if (jwt.isEmpty) {
+        throw Exception("JWT missing in response");
+      }
+      await _storePresenceJwt(jwt, sid);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> _storePresenceJwt(String jwt, String sid) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString("presence_jwt", jwt);
+    await prefs.setString("presence_sid", sid);
+  }
+
+  String _piJwtPrefKey() => "jwt_pi_id_for_widget_pi_$widgetPiId";
+
+  String _piBridgePrefKey() => "jwt_pi_bridge_for_widget_pi_$widgetPiId";
+
+  String _defaultPiJwtId() => "pi$widgetPiId";
+
+  Future<String> _getStoredPiJwtId() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_piJwtPrefKey()) ?? _defaultPiJwtId();
+  }
+
+  Future<void> _storePiJwtId(String piId) async {
+    if (piId.isEmpty) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_piJwtPrefKey(), piId);
+  }
+
+  Future<List<String>> _bridgeCandidates(
+    String preferredPiId, {
+    String? resolvedBridge,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_piBridgePrefKey());
+    final merged = <String>[
+      if (resolvedBridge != null && resolvedBridge.isNotEmpty) resolvedBridge,
+      if (stored != null && stored.isNotEmpty) stored,
+      "http://$preferredPiId.local:8080",
+      ..._defaultBridgeCandidates,
+    ];
+    final seen = <String>{};
+    final out = <String>[];
+    for (final base in merged) {
+      if (seen.add(base)) out.add(base);
+    }
+    return out;
+  }
+
+  Future<void> _storeBridgeBase(String base) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_piBridgePrefKey(), base);
+  }
+
+  Future<void> _clearPiBridgeCache() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_piBridgePrefKey());
+    await prefs.remove(_piJwtPrefKey());
+  }
+
+  Future<String> _fetchNonceHex() async {
+    final response = await http.get(Uri.parse("$_legacyApiBase/api/nonce"));
+    if (response.statusCode != 200) throw Exception("nonce failed");
+    final payload = jsonDecode(response.body) as Map<String, dynamic>;
+    return (payload["nonceHex"] as String).toLowerCase();
+  }
+
+  Future<bool> _postVerifyLegacy({
+    required String beaconIdHex,
+    required String nonceHex,
+    required String tsMs,
+    required String sigHex,
+  }) async {
+    final response = await http.post(
+      Uri.parse("$_legacyApiBase/api/verify"),
+      headers: {"Content-Type": "application/json"},
+      body: jsonEncode({
+        "beaconIdHex": beaconIdHex,
+        "nonceHex": nonceHex,
+        "tsMs": tsMs,
+        "sigHex": sigHex,
+      }),
+    );
+    return jsonDecode(response.body)["ok"] == true;
+  }
+
+  Future<BluetoothDevice> _scanForBeacon({required Duration timeout}) async {
+    try {
+      await FlutterBluePlus.stopScan();
+    } catch (_) {}
+    BluetoothDevice? found;
+    final sub = FlutterBluePlus.scanResults.listen((results) {
+      for (final result in results) {
+        if (result.advertisementData.serviceUuids.contains(_serviceUuid)) {
+          found = result.device;
+          break;
+        }
+      }
+    });
+
+    try {
+      await FlutterBluePlus.startScan(
+        withServices: [_serviceUuid],
+        timeout: timeout,
+      );
+      await Future.delayed(timeout);
+      await FlutterBluePlus.stopScan();
+      if (found == null) throw Exception("No beacon found");
+      return found!;
+    } finally {
+      await sub.cancel();
+    }
+  }
+
+  static String _bytesToHex(List<int> bytes) =>
+      bytes.map((value) => value.toRadixString(16).padLeft(2, "0")).join();
+
+  static Uint8List _hexToBytes(String hex) {
+    final out = Uint8List(hex.length ~/ 2);
+    for (int i = 0; i < out.length; i++) {
+      out[i] = int.parse(hex.substring(i * 2, i * 2 + 2), radix: 16);
+    }
+    return out;
+  }
+
+  static int _be64ToMs(Uint8List bytes) {
+    BigInt value = BigInt.zero;
+    for (int i = 0; i < 8; i++) {
+      value = (value << 8) | BigInt.from(bytes[i]);
+    }
+    return value.toInt();
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   csslib:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.3
+  cryptography: ^2.7.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
- extract JWT/BLE verification logic from lib/screens/4_mascot_screen.dart into lib/utils/mascot_verification_helper.dart
- keep MascotScreen focused on UI state, status messaging, rewards, and navigation
- update verification flow to:
1. start with JWT immediately
2. show Verifying presence… for 3 seconds
3. switch to legacy fallback messaging after 3 seconds
4. let JWT and legacy run in parallel until the 6-second total timeout
5. succeed as soon as either path succeeds
- fix verification failure status coloring

Closes #85 #86 

Main purpose of this is for readability/modularity as the 4_mascot_screen.dart file was too long/cluttered and difficult to follow along sequentially. A few other minor bugs/issues are also resolved with this pr.